### PR TITLE
Feat: Run hooks with prek and target ci.skip

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -39,19 +39,86 @@ jobs:
         with:
           persist-credentials: false
 
+      # Default mode: run this repository's ci.skip hooks, which is
+      # what a caller with no inputs gets.
       - name: "Running local action: ${{ github.repository }}"
+        id: default_mode
         uses: ./
         with:
           # No need to checkout the local repository twice
           no_checkout: true
           branch_name: 'linting-test'
+          github_token: ${{ github.token }}
 
+      - name: 'Check default mode selected the ci.skip hooks'
+        shell: bash
+        env:
+          HOOKS_RUN: ${{ steps.default_mode.outputs.hooks_run }}
+        run: |
+          # Check default mode selected the ci.skip hooks
+          if [ "$HOOKS_RUN" != 'gha-workflow-linter' ]; then
+            echo 'Error: expected the ci.skip hook set ❌'
+            echo "Got: $HOOKS_RUN"
+            exit 1
+          fi
+          echo 'Default mode ran the ci.skip hooks ✅'
+
+      # An explicitly named subset of the local configuration
+      - name: "Running local action: ${{ github.repository }} [Subset]"
+        id: subset
+        uses: ./
+        with:
+          no_checkout: true
+          hooks: 'check-yaml, end-of-file-fixer'
+
+      - name: 'Check the subset ran'
+        shell: bash
+        env:
+          HOOKS_RUN: ${{ steps.subset.outputs.hooks_run }}
+        run: |
+          # Check the subset ran
+          if [ "$HOOKS_RUN" != 'check-yaml end-of-file-fixer' ]; then
+            echo 'Error: expected the requested hook subset ❌'
+            echo "Got: $HOOKS_RUN"
+            exit 1
+          fi
+          echo 'Explicit hook subset ran ✅'
+
+      # A configuration named on purpose runs in full, so this covers
+      # the run-all path even though the remote file has no ci.skip.
       # yamllint disable-line rule:line-length
       - name: "Running local action: ${{ github.repository }} [Config download]"
+        id: remote_config
         uses: ./
         with:
           # yamllint disable-line rule:line-length
           config_url: 'https://raw.githubusercontent.com/lfreleng-actions/test-python-project/refs/heads/main/resources/pre-commit-config.yaml'
+
+      - name: 'Check the remote configuration ran in full'
+        shell: bash
+        env:
+          HOOKS_RUN: ${{ steps.remote_config.outputs.hooks_run }}
+          CONFIG_FILE: ${{ steps.remote_config.outputs.config_file }}
+        run: |
+          # Check the remote configuration ran in full
+          if [ "$HOOKS_RUN" != 'all' ]; then
+            echo 'Error: an explicit config_url should run all hooks ❌'
+            echo "Got: $HOOKS_RUN"
+            exit 1
+          fi
+          # It must NOT have overwritten the repository configuration.
+          case "$CONFIG_FILE" in
+            "$GITHUB_WORKSPACE"/*)
+              echo 'Error: remote config landed in the workspace ❌'
+              echo "Path: $CONFIG_FILE"
+              exit 1
+              ;;
+          esac
+          if ! git diff --quiet -- .pre-commit-config.yaml; then
+            echo 'Error: repository configuration was modified ❌'
+            exit 1
+          fi
+          echo 'Remote configuration ran without touching the repo ✅'
 
       # Perform setup prior to running test(s)
       - name: 'Checkout sample project repository'
@@ -62,6 +129,31 @@ jobs:
           repository: 'lfreleng-actions/test-python-project'
           path: 'test-python-project'
 
+      # The sample project's configuration carries no ci.skip, so the
+      # default mode has nothing to run and must succeed quietly. This
+      # is the estate-wide case: a repository with nothing to lint
+      # must never block a merge.
+      # yamllint disable-line rule:line-length
+      - name: "Running local action: ${{ github.repository }} [No-op/test-python-project]"
+        id: noop
+        uses: ./
+        with:
+          path_prefix: 'test-python-project'
+          no_checkout: true
+
+      - name: 'Check the no-op case succeeded quietly'
+        shell: bash
+        env:
+          HOOKS_RUN: ${{ steps.noop.outputs.hooks_run }}
+        run: |
+          # Check the no-op case succeeded quietly
+          if [ -n "$HOOKS_RUN" ]; then
+            echo 'Error: expected no hooks to run ❌'
+            echo "Got: $HOOKS_RUN"
+            exit 1
+          fi
+          echo 'Empty ci.skip succeeded without running hooks ✅'
+
       # Deliberate failure; linting will not pass run against default branch
       # yamllint disable-line rule:line-length
       - name: "Running local action: ${{ github.repository }} [Fail/test-python-project]"
@@ -70,6 +162,7 @@ jobs:
         with:
           path_prefix: 'test-python-project'
           no_checkout: true
+          run_all_hooks: true
         continue-on-error: true
 
       - name: 'Error if step above did NOT fail'
@@ -88,3 +181,78 @@ jobs:
           no_checkout: true
           path_prefix: 'test-python-project'
           branch_name: 'linting-test'
+          run_all_hooks: true
+
+      # Rejection cases: each must fail rather than lint anything.
+      - name: 'Path traversal in config_path'
+        id: traversal
+        uses: ./
+        with:
+          no_checkout: true
+          config_path: '../.pre-commit-config.yaml'
+        continue-on-error: true
+
+      - name: 'Plaintext http config_url'
+        id: insecure_url
+        uses: ./
+        with:
+          no_checkout: true
+          config_url: 'http://example.org/config.yaml'
+        continue-on-error: true
+
+      - name: 'Mismatched config_sha256'
+        id: bad_digest
+        uses: ./
+        with:
+          no_checkout: true
+          # yamllint disable-line rule:line-length
+          config_url: 'https://raw.githubusercontent.com/lfreleng-actions/test-python-project/refs/heads/main/resources/pre-commit-config.yaml'
+          # yamllint disable-line rule:line-length
+          config_sha256: '0000000000000000000000000000000000000000000000000000000000000000'
+        continue-on-error: true
+
+      # A hook id beginning '-' would reach the prek command line as
+      # an option, and 'prek run --help' exits 0 -- reporting a pass
+      # for a hook that never ran.
+      - name: 'Hook id that is a prek option'
+        id: option_hook
+        uses: ./
+        with:
+          no_checkout: true
+          hooks: '--help'
+        continue-on-error: true
+
+      # A glob must reach validation as the literal character, not
+      # expanded against the checkout first.
+      - name: 'Glob as a hook id'
+        id: glob_hook
+        uses: ./
+        with:
+          no_checkout: true
+          hooks: '*'
+        continue-on-error: true
+
+      - name: 'Error if any rejection case did NOT fail'
+        shell: bash
+        env:
+          TRAVERSAL: ${{ steps.traversal.outcome }}
+          INSECURE_URL: ${{ steps.insecure_url.outcome }}
+          BAD_DIGEST: ${{ steps.bad_digest.outcome }}
+          OPTION_HOOK: ${{ steps.option_hook.outcome }}
+          GLOB_HOOK: ${{ steps.glob_hook.outcome }}
+        run: |
+          # Error if any rejection case did NOT fail
+          status=0
+          for check in \
+            "config_path traversal:$TRAVERSAL" \
+            "plaintext http config_url:$INSECURE_URL" \
+            "mismatched config_sha256:$BAD_DIGEST" \
+            "hook id that is a prek option:$OPTION_HOOK" \
+            "glob as a hook id:$GLOB_HOOK"; do
+            if [ "${check##*:}" = 'success' ]; then
+              echo "Error: ${check%:*} was NOT rejected ❌"
+              status=1
+            fi
+          done
+          [ "$status" -eq 0 ] || exit 1
+          echo 'All rejection cases failed as expected ✅'

--- a/README.md
+++ b/README.md
@@ -5,9 +5,20 @@
 
 # ⛔️ Standalone Linting Action
 
-This action runs linting checks as a standalone step, which is helpful
-for tools that do not run well (or cannot run) under the GitHub marketplace
-pre-commit.ci application.
+Runs pre-commit hooks with [prek](https://github.com/j178/prek),
+standalone from pre-commit.ci. The primary use case is hooks that
+pre-commit.ci cannot run: hooks needing network access at scan time,
+or hooks whose environments exceed the pre-commit.ci size limits.
+
+By default (no inputs) the action parses the repository's
+`.pre-commit-config.yaml`, takes the hook ids listed under `ci.skip`,
+and runs those hooks. When `ci.skip` is empty or absent, the
+action succeeds without running anything.
+
+To orchestrate parallel matrix jobs across more than one
+configuration, use the `linting.yaml` reusable workflow in
+[lfreleng-actions/generic-workflows](https://github.com/lfreleng-actions/generic-workflows),
+which builds a lint plan and calls this action for each task.
 
 ## standalone-linting-action
 
@@ -23,24 +34,130 @@ jobs:
     permissions:
       contents: read
     steps:
+      # Runs the hooks listed under ci.skip in .pre-commit-config.yaml
       - uses: lfreleng-actions/standalone-linting-action@main
+        with:
+          github_token: ${{ github.token }}
+```
+
+Run an explicit subset of hooks:
+
+```yaml
+      - uses: lfreleng-actions/standalone-linting-action@main
+        with:
+          hooks: 'mypy gitlint'
+```
+
+Run every hook from a remote configuration, with integrity pinning
+(naming a configuration implies running it in full):
+
+```yaml
+      - uses: lfreleng-actions/standalone-linting-action@main
+        with:
+          config_url: 'https://example.org/linting/.pre-commit-config.yaml'
+          config_sha256: '<sha256 of the configuration file>'
 ```
 
 ## Inputs
 
 <!-- markdownlint-disable MD013 -->
 
-| Variable Name    | Required | Description                                                | Default |
-| ---------------- | -------- | ---------------------------------------------------------- | ------- |
-| config_url       | False    | Download location for pre-commit configuration             |         |
-| dependencies_url | False    | Download location for supplementary Python dependencies    | None    |
-| branch_name      | False    | Checkout this new Git branch before running linting checks | None    |
-| path_prefix      | False    | Directory location containing project code                 | .       |
-| no_checkout      | False    | Don't perform a checkout of the local repository           | false   |
-| python-version   | False    | Python version used to run linting tools                   | 3.12    |
+| Variable Name | Required | Description                                                           | Default |
+| ------------- | -------- | --------------------------------------------------------------------- | ------- |
+| hooks         | False    | Space/comma separated hook ids to run; empty runs the ci.skip hooks   |         |
+| run_all_hooks | False    | Run every hook in the configuration (exclusive with hooks)            | false   |
+| config_path   | False    | Configuration path; workspace-relative, or absolute in RUNNER_TEMP    |         |
+| config_url    | False    | HTTPS download URL for the configuration (exclusive with config_path) |         |
+| config_sha256 | False    | Expected SHA-256 of the file fetched from config_url                  |         |
+| path_prefix   | False    | Directory location containing project code                            | .       |
+| branch_name   | False    | Checkout this new Git branch before running linting checks            |         |
+| no_checkout   | False    | Don't perform a checkout of the local repository                      | false   |
+| github_token  | False    | Token exported as GITHUB_TOKEN/GH_TOKEN to hooks needing API access   |         |
+| prek_version  | False    | Version of prek used to run the hooks (X.Y.Z)                         | 0.4.14  |
 
 <!-- markdownlint-enable MD013 -->
 
-Caution: dash NOT underscore in python-version input/name
+## Outputs
 
-(This maintains alignment with other common actions, e.g. actions/setup-python)
+<!-- markdownlint-disable MD013 -->
+
+| Output Name | Description                                                             |
+| ----------- | ----------------------------------------------------------------------- |
+| config_file | Resolved path of the linting configuration file                         |
+| hooks_run   | Space-separated hook ids run; 'all' for run_all_hooks; empty when no-op |
+
+<!-- markdownlint-enable MD013 -->
+
+## Behaviour
+
+Mode selection:
+
+1. `hooks` set: run the named hook ids
+2. `run_all_hooks: 'true'`, or `config_path`/`config_url` supplied:
+   run every hook in the configuration
+3. Neither (default): run the hooks listed under `ci.skip` in the
+   configuration; succeed with a notice when the list is empty
+
+A configuration named on purpose runs in full. Its `ci.skip` describes
+what pre-commit.ci skips for the repository that owns it, which says
+nothing about a file you pointed the action at; falling to `ci.skip`
+mode would run nothing at all for most such files. Pass `hooks` to
+narrow it.
+
+Hook ids must match `[A-Za-z0-9][A-Za-z0-9._-]*` — alphanumeric first
+character, then alphanumerics, dots, underscores and hyphens. The
+action rejects anything else rather than pass it to a shell. The
+leading-character rule matters in its own right: an id beginning `-`
+would reach the prek command line as an *option*, and `prek run
+--help` exits 0, reporting a hook as passed without running it. The
+action also terminates option parsing with `--`, so both locks have
+to fail before that becomes possible.
+
+Every hook id in practical use fits this, though the rule is narrower
+than pre-commit's schema, which types `id` as a free-form string.
+
+Configuration file resolution order:
+
+1. `config_url` (downloaded to the runner temp directory)
+2. `config_path`
+3. `<path_prefix>/.pre-commit-config.yaml`
+
+A remote configuration never overwrites files in the repository; the
+action passes it to prek with `--config`.
+
+## Security
+
+- No secrets required; `github_token` is optional, and reaches no
+  further than the hook environment
+- All variable data reaches shell steps through `env`, never through
+  expression interpolation in `run` blocks
+- Hook ids are allow-listed to `[A-Za-z0-9][A-Za-z0-9._-]*`, so a
+  configuration cannot smuggle shell metacharacters onto the prek
+  command line, nor a leading `-` that prek would read as an option
+- The action rejects control characters (notably CR/LF) in every
+  string input, which closes the per-line anchoring of `grep -E` and
+  keeps `GITHUB_OUTPUT` records single-line
+- `path_prefix` stays within the repository workspace, and
+  `config_path` within the workspace or `RUNNER_TEMP` (the latter for
+  configurations an orchestrating workflow staged); the action
+  resolves both with `realpath` and rejects `..` segments and symlink
+  escapes
+- A remote configuration lands in a private `mktemp` directory, never
+  a predictable path a pre-created symlink could redirect into the
+  workspace
+- `config_url` must be HTTPS; downloads are size- and time-capped and
+  support `config_sha256` integrity pinning
+- prek installs via `uvx` at an exact pinned version
+
+## Breaking changes from v0.2.x
+
+- Hooks run with `prek` instead of `pre-commit`
+- The default mode changed from "run all hooks" to "run the hooks
+  listed under `ci.skip`"; set `run_all_hooks: 'true'` to restore the
+  previous behaviour
+- `config_url` downloads to a private directory under `RUNNER_TEMP`
+  instead of overwriting `.pre-commit-config.yaml` in the workspace
+- The `dependencies_url` input no longer exists; declare hook
+  dependencies with `additional_dependencies` in the hook definition
+- The `python-version` input no longer exists; prek provisions the
+  toolchains (Python via uv, Node.js) that hook environments declare

--- a/action.yaml
+++ b/action.yaml
@@ -3,33 +3,119 @@
 # SPDX-FileCopyrightText: 2025 The Linux Foundation
 
 # standalone-linting-action
+#
+# Runs pre-commit hooks with prek <https://github.com/j178/prek>,
+# standalone from pre-commit.ci. The primary use case is hooks that
+# pre-commit.ci cannot run: hooks needing network access at scan time,
+# or hooks whose environments exceed the pre-commit.ci size limits.
+#
+# Default behaviour (no inputs): parse the repository's
+# .pre-commit-config.yaml, take the hook ids listed under 'ci.skip',
+# and run exactly those hooks. When 'ci.skip' is empty or absent the
+# action succeeds without running anything.
+#
+# Other modes:
+#   * hooks: '<ids>'        run an explicit subset of hooks
+#   * run_all_hooks: 'true' run every hook in the configuration
+#   * config_path/config_url select an alternate configuration file,
+#     which runs in full unless 'hooks' names a subset
+#
+# Security posture:
+#   * No secrets required; an optional github_token is only exported
+#     to hooks that need authenticated API access.
+#   * All variable data reaches shell steps through 'env', never
+#     through expression interpolation inside 'run' blocks.
+#   * Hook ids are allow-listed to [A-Za-z0-9._-], so a configuration
+#     cannot smuggle shell metacharacters onto the prek command line.
+#   * config_path is confined to the workspace or the runner temp
+#     directory (symlink escapes rejected via realpath).
+#   * config_url must be HTTPS, downloads to a private mktemp
+#     directory (never overwriting repository files, and never a
+#     predictable path a symlink could redirect), is size- and
+#     time-capped, and supports sha256 integrity pinning.
+#     (never overwriting repository files), is size- and time-capped,
+#     and supports sha256 integrity pinning.
 name: '⛔️ Standalone Linting Action'
-description: 'Runs linting tools that do NOT run under pre-commit.ci'
+description: 'Runs pre-commit linting hooks with prek, outside pre-commit.ci'
 
 inputs:
   # Optional
+  hooks:
+    description: >-
+      Space or comma separated hook ids to run from the configuration.
+      Hook ids must match [A-Za-z0-9._-]; the action rejects anything
+      else rather than pass it to a shell. Empty selects the default
+      mode: run the hooks listed under 'ci.skip' in the configuration
+      file.
+    required: false
+    default: ''
+  run_all_hooks:
+    description: >-
+      Set 'true' to run every hook in the configuration file.
+      Mutually exclusive with the hooks input. Supplying config_path
+      or config_url implies this.
+    required: false
+    default: 'false'
+  config_path:
+    description: >-
+      Path to the pre-commit configuration file. Relative paths
+      resolve inside the repository workspace; absolute paths must
+      live under the runner temp directory (for configurations staged
+      by an orchestrating workflow). Empty uses
+      <path_prefix>/.pre-commit-config.yaml. Implies run_all_hooks
+      unless the hooks input names a subset.
+    required: false
+    default: ''
   config_url:
-    description: 'Download URL for pre-commit linting configuration file'
+    description: >-
+      HTTPS download URL for the pre-commit configuration file.
+      Downloaded to a private directory under the runner temp
+      directory; never overwrites repository files. Mutually
+      exclusive with config_path. Implies run_all_hooks unless the
+      hooks input names a subset.
     required: false
-  dependencies_url:
-    description: 'Download location for additional Python dependencies'
+    default: ''
+  config_sha256:
+    description: >-
+      Expected SHA-256 checksum of the file fetched from config_url.
+      Strongly recommended whenever config_url is set.
     required: false
-  branch_name:
-    # Prevents linting errors that mandate changes be made on a branch
-    description: 'Checkout this branch name prior to running linting'
+    default: ''
   path_prefix:
     description: 'Directory location containing project code'
     required: false
     default: '.'
+  branch_name:
+    # Prevents linting errors that mandate changes be made on a branch
+    description: 'Checkout this branch name prior to running linting'
+    required: false
+    default: ''
   no_checkout:
     description: 'Do not checkout local repository; used for testing'
     required: false
     default: 'false'
-  python-version:
-    # Only used when pyproject.toml file not present
-    description: 'Python version used to run pre-commit hooks'
+  github_token:
+    description: >-
+      Optional token exported to hooks as GITHUB_TOKEN/GH_TOKEN, for
+      linters that call the GitHub API (e.g. gha-workflow-linter).
+      Pass secrets.GITHUB_TOKEN or github.token; never a PAT with
+      broader scope than the job needs.
     required: false
-    default: '3.12'
+    default: ''
+  prek_version:
+    description: 'Version of prek used to run the hooks (X.Y.Z)'
+    required: false
+    default: '0.4.14'
+
+outputs:
+  config_file:
+    description: 'Resolved path of the linting configuration file'
+    value: ${{ steps.resolve.outputs.config_file }}
+  hooks_run:
+    description: >-
+      Space-separated hook ids the action ran; 'all' when
+      run_all_hooks was set; empty when there was nothing to do.
+    value: ${{ steps.resolve.outputs.hooks_label }}
 
 runs:
   using: 'composite'
@@ -41,100 +127,413 @@ runs:
         persist-credentials: false
       if: inputs.no_checkout != 'true'
 
-    - name: 'Check path_prefix directory'
-      if: inputs.path_prefix != '.'
+    - name: 'Validate inputs'
       shell: bash
       env:
-        INPUT_PATH_PREFIX: ${{ inputs.path_prefix }}
-      run: |
-        if [ ! -d "$INPUT_PATH_PREFIX" ]; then
-          echo 'Error: path_prefix is not a valid directory ❌'
-          echo "$INPUT_PATH_PREFIX"
-          exit 1
-        fi
-
-    - name: 'Cache pip packages'
-      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/pyproject.toml') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
-
-    # yamllint disable-line rule:line-length
-    - uses: lfreleng-actions/path-check-action@b51f09959a4a71eff2e2f175bf80400ae8576f63 # v0.2.1
-      id: pyproject-toml
-      with:
-        path: "${{ inputs.path_prefix }}/pyproject.toml"
-
-    - name: 'Set up Python [pyproject.toml]'
-      if: steps.pyproject-toml.outputs.type == 'file'
-      # yamllint disable-line rule:line-length
-      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
-      with:
-        python-version-file: "${{ inputs.path_prefix }}/pyproject.toml"
-
-    - name: "Setup Python ${{ inputs.python-version }}"
-      # yamllint disable-line rule:line-length
-      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
-      with:
-        python-version: "${{ inputs.python-version }}"
-
-    - name: 'Install pre-commit'
-      shell: bash
-      run:
-        # Install pre-commit
-        pip install --disable-pip-version-check pre-commit
-
-    - name: 'Download Python dependencies configuration'
-      if: inputs.dependencies_url != ''
-      # yamllint disable-line rule:line-length
-      uses: lfreleng-actions/url-download-action@77920845b3cef96fac9ef287dcff261b24a12341 # v0.1.5
-      with:
-        url: "${{ inputs.dependencies_url }}"
-        path: '/tmp/requirements.txt'
-
-    - name: 'Install additional Python dependencies'
-      if: inputs.dependencies_url != ''
-      shell: bash
-      run:
-        # Install additional Python dependencies
-        pip install --disable-pip-version-check -r /tmp/requirements.txt
-
-    - name: 'Download remote pre-commit configuration'
-      # yamllint disable-line rule:line-length
-      if: inputs.config_url != ''
-      # yamllint disable-line rule:line-length
-      uses: lfreleng-actions/url-download-action@77920845b3cef96fac9ef287dcff261b24a12341 # v0.1.5
-      with:
-        url: "${{ inputs.config_url }}"
-        # Will overwrite existing file; upstream action uses "wget -O" flag
-        path: '.pre-commit-config.yaml'
-        exit_on_fail: true
-
-    - name: 'Validate linting configuration'
-      shell: bash
-      env:
+        INPUT_HOOKS: ${{ inputs.hooks }}
+        INPUT_RUN_ALL_HOOKS: ${{ inputs.run_all_hooks }}
+        INPUT_CONFIG_PATH: ${{ inputs.config_path }}
+        INPUT_CONFIG_URL: ${{ inputs.config_url }}
+        INPUT_CONFIG_SHA256: ${{ inputs.config_sha256 }}
         INPUT_PATH_PREFIX: ${{ inputs.path_prefix }}
         INPUT_BRANCH_NAME: ${{ inputs.branch_name }}
+        INPUT_PREK_VERSION: ${{ inputs.prek_version }}
       run: |
-        # Validate linting configuration
-        if [ "$INPUT_PATH_PREFIX" != '.' ]; then
-          cd "$INPUT_PATH_PREFIX"
+        # Validate inputs
+        set -euo pipefail
+        errors=0
+        err() { echo "::error::$1 ❌"; errors=1; }
+
+        # Reject control characters (notably CR/LF) in every string
+        # input, before any other check.
+        #
+        # Two reasons. First, 'grep -qE ^...$' anchors per LINE, so a
+        # multi-line value whose lines each match slips past the
+        # patterns below. Second, a resolved path carrying a newline
+        # would corrupt the single-line 'name=value' records this
+        # action writes to GITHUB_OUTPUT, truncating a value or
+        # injecting an extra record. A bash pattern match sees the
+        # whole value, so it catches what the line-oriented tools
+        # cannot.
+        check_clean() {
+          # $1=value $2=label
+          if [[ "$1" == *[$'\n\r\t\v\f']* ]]; then
+            err "$2 must not contain control characters"
+            return 1
+          fi
+          return 0
+        }
+
+        check_clean "$INPUT_HOOKS" 'hooks' || true
+        check_clean "$INPUT_CONFIG_PATH" 'config_path' || true
+        check_clean "$INPUT_CONFIG_URL" 'config_url' || true
+        check_clean "$INPUT_PATH_PREFIX" 'path_prefix' || true
+        check_clean "$INPUT_BRANCH_NAME" 'branch_name' || true
+        [ "$errors" -eq 0 ] || exit 1
+
+        case "$INPUT_RUN_ALL_HOOKS" in
+          true|false) ;;
+          *) err "run_all_hooks must be 'true' or 'false'" ;;
+        esac
+        if [ "$INPUT_RUN_ALL_HOOKS" = 'true' ] && [ -n "$INPUT_HOOKS" ]
+        then
+          err 'hooks and run_all_hooks are mutually exclusive'
         fi
+        # Every hook id must START with an alphanumeric. A leading '-'
+        # would otherwise reach the prek command line as an OPTION:
+        # 'prek run --help' prints help and exits 0, so the action
+        # would report a hook as passed without ever running it.
+        #
+        # 'read -ra' splits on IFS WITHOUT pathname expansion. An
+        # unquoted expansion would glob first, so 'hooks: *' would
+        # validate the file names in the checkout rather than the
+        # literal '*' the resolver goes on to use.
+        if [ -n "$INPUT_HOOKS" ]; then
+          read -ra hook_ids <<< "${INPUT_HOOKS//,/ }"
+          for hook_id in "${hook_ids[@]}"; do
+            if ! printf '%s' "$hook_id" |
+              grep -qE '^[A-Za-z0-9][A-Za-z0-9._-]*$'; then
+              err "invalid hook id: $hook_id"
+            fi
+          done
+        fi
+        if [ -n "$INPUT_CONFIG_PATH" ] && [ -n "$INPUT_CONFIG_URL" ]
+        then
+          err 'config_path and config_url are mutually exclusive'
+        fi
+        if [ -n "$INPUT_CONFIG_URL" ]; then
+          case "$INPUT_CONFIG_URL" in
+            https://?*) ;;
+            *) err 'config_url must be an https:// URL' ;;
+          esac
+          if ! printf '%s' "$INPUT_CONFIG_URL" |
+            grep -qE '^https://[A-Za-z0-9._~:/?#@$&()*+,;=%-]+$'; then
+            err 'config_url contains unsupported characters'
+          fi
+        fi
+        if [ -n "$INPUT_CONFIG_SHA256" ]; then
+          if [ -z "$INPUT_CONFIG_URL" ]; then
+            err 'config_sha256 requires config_url'
+          fi
+          if ! printf '%s' "$INPUT_CONFIG_SHA256" |
+            grep -qE '^[0-9a-fA-F]{64}$'; then
+            err 'config_sha256 must be a 64-character hex digest'
+          fi
+        fi
+        if ! printf '%s' "$INPUT_PREK_VERSION" |
+          grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+          err 'prek_version must be a bare X.Y.Z version'
+        fi
+        if [ -n "$INPUT_BRANCH_NAME" ]; then
+          if ! printf '%s' "$INPUT_BRANCH_NAME" |
+            grep -qE '^[A-Za-z0-9._/-]+$'; then
+            err 'branch_name contains unsupported characters'
+          fi
+          case "/$INPUT_BRANCH_NAME/" in
+            */../*) err "branch_name must not contain '..'" ;;
+          esac
+        fi
+
+        # Path containment: reject absolute paths and '..' segments,
+        # then resolve symlinks and confirm the real path stays inside
+        # the permitted root(s).
+        ws=$(realpath -e -- "$GITHUB_WORKSPACE")
+        tmp=$(realpath -e -- "$RUNNER_TEMP")
+
+        case "$INPUT_PATH_PREFIX" in
+          /*) err 'path_prefix must be a relative path' ;;
+          *)
+            case "/$INPUT_PATH_PREFIX/" in
+              */../*) err "path_prefix must not contain '..'" ;;
+              *)
+                if abs=$(realpath -e -- "$ws/$INPUT_PATH_PREFIX" \
+                  2>/dev/null); then
+                  case "$abs" in
+                    "$ws"|"$ws"/*)
+                      if [ ! -d "$abs" ]; then
+                        err 'path_prefix is not a directory'
+                      fi
+                      ;;
+                    *) err 'path_prefix escapes the workspace' ;;
+                  esac
+                else
+                  err "path_prefix is not a valid directory:" \
+                    "$INPUT_PATH_PREFIX"
+                fi
+                ;;
+            esac
+            ;;
+        esac
+
+        if [ -n "$INPUT_CONFIG_PATH" ]; then
+          case "$INPUT_CONFIG_PATH" in
+            /*)
+              # Absolute paths permitted only under the runner temp
+              # directory, for configurations staged by a workflow.
+              if abs=$(realpath -e -- "$INPUT_CONFIG_PATH" \
+                2>/dev/null); then
+                case "$abs" in
+                  "$tmp"/*) ;;
+                  *) err 'absolute config_path must live under' \
+                    'the runner temp directory' ;;
+                esac
+              else
+                err "config_path does not exist: $INPUT_CONFIG_PATH"
+              fi
+              ;;
+            *)
+              case "/$INPUT_CONFIG_PATH/" in
+                */../*) err "config_path must not contain '..'" ;;
+                *)
+                  if abs=$(realpath -e -- "$ws/$INPUT_CONFIG_PATH" \
+                    2>/dev/null); then
+                    case "$abs" in
+                      "$ws"/*) ;;
+                      *) err 'config_path escapes the workspace' ;;
+                    esac
+                  else
+                    err "config_path does not exist:" \
+                      "$INPUT_CONFIG_PATH"
+                  fi
+                  ;;
+              esac
+              ;;
+          esac
+        fi
+
+        [ "$errors" -eq 0 ] || exit 1
+
+    - name: 'Download remote configuration'
+      id: download
+      if: inputs.config_url != ''
+      shell: bash
+      env:
+        INPUT_CONFIG_URL: ${{ inputs.config_url }}
+        INPUT_CONFIG_SHA256: ${{ inputs.config_sha256 }}
+      run: |
+        # Download remote configuration
+        set -euo pipefail
+        # A private directory with an unpredictable name, NOT a fixed
+        # path: 'curl --output' follows an existing symlink, so a
+        # pre-created path could otherwise redirect the write into the
+        # workspace.
+        dir=$(mktemp -d "$RUNNER_TEMP/standalone-linting.XXXXXXXX")
+        chmod 700 "$dir"
+        target="$dir/remote-config.yaml"
+        curl --proto '=https' --tlsv1.2 --fail --silent --show-error \
+          --location --max-redirs 3 --max-filesize 1048576 \
+          --max-time 60 --output "$target" "$INPUT_CONFIG_URL"
+        if [ -n "$INPUT_CONFIG_SHA256" ]; then
+          digest=$(printf '%s' "$INPUT_CONFIG_SHA256" |
+            tr '[:upper:]' '[:lower:]')
+          echo "$digest  $target" | sha256sum --check --strict -
+          echo 'Remote configuration checksum verified ✅'
+        else
+          echo '::warning::config_url fetched without config_sha256;' \
+            'pin a checksum to guarantee integrity'
+        fi
+        echo "config_file=$target" >> "$GITHUB_OUTPUT"
+
+    - name: 'Set up uv'
+      # yamllint disable-line rule:line-length
+      uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+      with:
+        version: '0.12.4'
+
+    - name: 'Resolve configuration and hooks'
+      id: resolve
+      shell: bash
+      env:
+        INPUT_HOOKS: ${{ inputs.hooks }}
+        INPUT_RUN_ALL_HOOKS: ${{ inputs.run_all_hooks }}
+        INPUT_CONFIG_PATH: ${{ inputs.config_path }}
+        INPUT_CONFIG_URL: ${{ inputs.config_url }}
+        INPUT_PATH_PREFIX: ${{ inputs.path_prefix }}
+        DOWNLOADED_CONFIG: ${{ steps.download.outputs.config_file }}
+      run: |
+        # Resolve configuration and hooks
+        set -euo pipefail
+        if [ -n "$INPUT_CONFIG_URL" ]; then
+          cfg="$DOWNLOADED_CONFIG"
+        elif [ -n "$INPUT_CONFIG_PATH" ]; then
+          case "$INPUT_CONFIG_PATH" in
+            /*) cfg="$INPUT_CONFIG_PATH" ;;
+            *) cfg="$GITHUB_WORKSPACE/$INPUT_CONFIG_PATH" ;;
+          esac
+        else
+          cfg="$GITHUB_WORKSPACE/$INPUT_PATH_PREFIX"
+          cfg="$cfg/.pre-commit-config.yaml"
+        fi
+        if ! cfg=$(realpath -e -- "$cfg"); then
+          echo '::error::No linting configuration file found ❌'
+          exit 1
+        fi
+        # The resolved path goes into a single-line GITHUB_OUTPUT
+        # record. A file name carrying a newline would truncate the
+        # value or inject a further record, so refuse it here rather
+        # than corrupt the step outputs.
+        if [[ "$cfg" == *[$'\n\r']* ]]; then
+          echo '::error::configuration path contains a newline ❌'
+          exit 1
+        fi
+        echo "Linting configuration: $cfg 💬"
+
+        hooks=''
+        run_all='false'
+        run_needed='true'
+        if [ -n "$INPUT_HOOKS" ]; then
+          hooks=$(printf '%s' "$INPUT_HOOKS" | tr ',' ' ' |
+            tr -s ' ' | sed -e 's/^ //' -e 's/ $//')
+        elif [ "$INPUT_RUN_ALL_HOOKS" = 'true' ]; then
+          run_all='true'
+        elif [ -n "$INPUT_CONFIG_URL" ] ||
+          [ -n "$INPUT_CONFIG_PATH" ]; then
+          # An explicitly supplied configuration runs in full. Its
+          # 'ci.skip' describes what pre-commit.ci skips for the
+          # repository that owns it, which says nothing about a
+          # configuration named here on purpose; falling to ci.skip
+          # mode would silently run nothing for most such files.
+          run_all='true'
+          echo 'Explicit configuration supplied; running all hooks 💬'
+        else
+          # Default mode: run the hooks pre-commit.ci skips. Parse
+          # ci.skip and keep only ids the configuration defines.
+          hooks=$(uv run --no-project --with pyyaml==6.0.2 \
+            python - "$cfg" <<'PYEOF'
+        import re
+        import sys
+
+        import yaml
+
+        with open(sys.argv[1], encoding="utf-8") as handle:
+            cfg = yaml.safe_load(handle) or {}
+        if not isinstance(cfg, dict):
+            sys.exit("configuration is not a YAML mapping")
+        ci_block = cfg.get("ci") or {}
+        skip = ci_block.get("skip") if isinstance(ci_block, dict) else []
+        skip = [str(item) for item in (skip or [])]
+        defined = []
+        for repo in cfg.get("repos") or []:
+            if not isinstance(repo, dict):
+                continue
+            for hook in repo.get("hooks") or []:
+                if isinstance(hook, dict) and hook.get("id"):
+                    defined.append(str(hook["id"]))
+        selected = [item for item in skip if item in defined]
+        for item in selected:
+            # Must start alphanumeric: a leading '-' would reach the
+            # prek command line as an option ('run --help' exits 0),
+            # reporting a pass without running the hook.
+            if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,99}", item):
+                sys.exit(f"invalid hook id in ci.skip: {item!r}")
+        print(" ".join(dict.fromkeys(selected)))
+        PYEOF
+          )
+          if [ -z "$hooks" ]; then
+            run_needed='false'
+            echo '::notice::ci.skip lists no runnable hooks;' \
+              'nothing to do ✅'
+          fi
+        fi
+
+        if [ "$run_all" = 'true' ]; then
+          hooks_label='all'
+        else
+          hooks_label="$hooks"
+        fi
+        config_hash=$(sha256sum "$cfg" | awk '{print $1}')
+        {
+          echo "config_file=$cfg"
+          echo "hooks=$hooks"
+          echo "hooks_label=$hooks_label"
+          echo "run_all=$run_all"
+          echo "run_needed=$run_needed"
+          echo "config_hash=$config_hash"
+        } >> "$GITHUB_OUTPUT"
+
+    - name: 'Cache prek hook environments'
+      if: steps.resolve.outputs.run_needed == 'true'
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ~/.cache/prek
+        # yamllint disable-line rule:line-length
+        key: prek-${{ runner.os }}-${{ inputs.prek_version }}-${{ steps.resolve.outputs.config_hash }}
+        restore-keys: |
+          prek-${{ runner.os }}-${{ inputs.prek_version }}-
+
+    - name: 'Run linting checks'
+      if: steps.resolve.outputs.run_needed == 'true'
+      shell: bash
+      env:
+        CONFIG_FILE: ${{ steps.resolve.outputs.config_file }}
+        RESOLVED_HOOKS: ${{ steps.resolve.outputs.hooks }}
+        RUN_ALL: ${{ steps.resolve.outputs.run_all }}
+        INPUT_PATH_PREFIX: ${{ inputs.path_prefix }}
+        INPUT_BRANCH_NAME: ${{ inputs.branch_name }}
+        INPUT_PREK_VERSION: ${{ inputs.prek_version }}
+        GITHUB_TOKEN: ${{ inputs.github_token }}
+        GH_TOKEN: ${{ inputs.github_token }}
+      run: |
+        # Run linting checks
+        set -euo pipefail
+        # Hooks probing for a token behave better with the variables
+        # absent than empty.
+        if [ -z "${GITHUB_TOKEN:-}" ]; then
+          unset GITHUB_TOKEN GH_TOKEN
+        fi
+        export PREK_HOME="$HOME/.cache/prek"
+        cd "$INPUT_PATH_PREFIX"
         if [ -n "$INPUT_BRANCH_NAME" ]; then
           echo "Checking out Git branch: $INPUT_BRANCH_NAME 💬"
           git checkout -b "$INPUT_BRANCH_NAME"
         fi
-        pre-commit validate-config
-
-    - name: 'Run all pre-commit hooks'
-      shell: bash
-      env:
-        INPUT_PATH_PREFIX: ${{ inputs.path_prefix }}
-      run: |
-        # Run all pre-commit hooks
-        if [ "$INPUT_PATH_PREFIX" != '.' ]; then
-          cd "$INPUT_PATH_PREFIX"
+        status=0
+        rows=''
+        if [ "$RUN_ALL" = 'true' ]; then
+          if uvx "prek@$INPUT_PREK_VERSION" run --all-files \
+            --show-diff-on-failure --config "$CONFIG_FILE"; then
+            rows='| all hooks | ✅ |'
+          else
+            rows='| all hooks | ❌ |'
+            status=1
+          fi
+        else
+          read -ra hook_list <<< "$RESOLVED_HOOKS"
+          for hook in "${hook_list[@]}"; do
+            echo "::group::prek run $hook"
+            # '--' terminates option parsing: without it a hook id
+            # beginning '-' would be read as a prek option, and
+            # 'run --help' exits 0, reporting a pass for a hook that
+            # never ran. Validation rejects such ids too; this is the
+            # second of the two locks.
+            if uvx "prek@$INPUT_PREK_VERSION" run --all-files \
+              --show-diff-on-failure --config "$CONFIG_FILE" \
+              -- "$hook"; then
+              rows="$rows| $hook | ✅ |"$'\n'
+            else
+              rows="$rows| $hook | ❌ |"$'\n'
+              status=1
+            fi
+            echo '::endgroup::'
+          done
         fi
-        pre-commit run -a
+        {
+          echo '## ⛔️ Standalone Linting'
+          echo ''
+          echo '| Hook | Result |'
+          echo '| ---- | ------ |'
+          printf '%s' "$rows"
+          echo ''
+        } >> "$GITHUB_STEP_SUMMARY"
+        exit "$status"
+
+    - name: 'Nothing to run'
+      if: steps.resolve.outputs.run_needed != 'true'
+      shell: bash
+      run: |
+        # Nothing to run
+        {
+          echo '## ⛔️ Standalone Linting'
+          echo ''
+          echo 'No hooks to run: ci.skip lists no runnable hooks ✅'
+        } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

The action ran every hook with `pre-commit`, duplicating the work pre-commit.ci already does and missing the hooks it cannot run. Those hooks are the reason to run standalone: pre-commit.ci blocks network access at scan time and caps environment size, so repositories list them under `ci.skip` and they never run in CI at all.

This makes that set the default, swaps `pre-commit` for `prek`, and closes four security gaps found along the way.

## Behaviour

Mode selection:

| Given | Runs |
| --- | --- |
| `hooks` | The named hook ids |
| `run_all_hooks: 'true'`, or `config_path`/`config_url` | Every hook in the configuration |
| Nothing (default) | The hook ids listed under `ci.skip` |

An empty or absent `ci.skip` succeeds with a notice rather than failing — the estate-wide "nothing to lint must not block a merge" case.

A configuration named on purpose runs in full. Its `ci.skip` describes what pre-commit.ci skips for the repository that *owns* it, which says nothing about a file you pointed the action at; falling to `ci.skip` mode would run nothing at all for most such files. Pass `hooks` to narrow it.

Configuration resolution: `config_url` → `config_path` → `<path_prefix>/.pre-commit-config.yaml`.

## Security fixes

- `config_url` **overwrote** `.pre-commit-config.yaml` in the workspace; it now downloads to a private `mktemp -d` directory (mode `700`) and reaches prek via `--config`, so it never touches repository files
- The download destination is no longer a **predictable path** — `curl --output` follows an existing symlink, so a pre-created path could have redirected the write into the workspace
- `path_prefix` accepted `../` traversal and symlink escapes; both `path_prefix` and `config_path` now resolve with `realpath` and must stay inside `GITHUB_WORKSPACE` (or `RUNNER_TEMP` for staged configurations)
- Downloads were unbounded; they now cap size (1 MiB), time and redirects, require HTTPS, and support `config_sha256` integrity pinning
- Hook ids are allow-listed to `[A-Za-z0-9._-]`, so an attacker-controlled configuration cannot smuggle shell metacharacters onto the prek command line
- All variable data reaches shell steps through `env`, never through expression interpolation in `run` blocks

## Bug fix

The second `setup-python` step carried no condition, so it always ran and clobbered the version derived from `pyproject.toml`.

## Tests

`.github/workflows/testing.yaml` is rewritten around the new modes and now asserts outcomes rather than just exit status:

- default mode → `hooks_run == 'gha-workflow-linter'` (this repo's `ci.skip`)
- explicit subset → `hooks_run` matches the request
- `config_url` → `hooks_run == 'all'`, resolved path outside `$GITHUB_WORKSPACE`, and `git diff --quiet -- .pre-commit-config.yaml` clean
- **no-op** case against `test-python-project` (no `ci.skip`) → empty `hooks_run`, success
- deliberate failure and passing cases, both with `run_all_hooks: true`
- three rejection cases: `config_path` traversal, plaintext `http` URL, mismatched `config_sha256`

## Breaking changes

- Hooks run with `prek` instead of `pre-commit`
- Default changed from "run all hooks" to "run the `ci.skip` hooks"; set `run_all_hooks: 'true'` to restore the old behaviour
- `config_url` no longer overwrites the workspace configuration
- `dependencies_url` removed — `additional_dependencies` in the hook definition covers this properly
- `python-version` removed — prek provisions the toolchains hook environments declare

## New inputs and outputs

Inputs: `hooks`, `run_all_hooks`, `config_path`, `config_sha256`, `github_token`, `prek_version`.
Outputs: `config_file`, `hooks_run` (which the tests above assert on).

## Related

The `linting.yaml` reusable workflow in lfreleng-actions/generic-workflows#34 builds a lint plan and calls this action once per parallel task. **Merge this PR first**; that one pins this branch's head and must be re-pinned to a released SHA afterwards.

## Validation

- `zizmor --persona=auditor action.yaml .github/workflows/testing.yaml` — no findings
- `actionlint` (v1.7.12) — clean
- `prek run --all-files` — all hooks pass
- `ci.skip` parsing verified against a real config (correctly extracts `gha-workflow-linter aislop`)
