### PR TITLE
Feat: Add skip_hooks to exclude hooks from a run

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -84,6 +84,93 @@ jobs:
           fi
           echo 'Explicit hook subset ran ✅'
 
+      # skip_hooks is the ONLY way to say "run everything except
+      # these": hooks names a subset to include, which cannot express
+      # an exclusion. This is the shape a caller migrating from
+      # 'pre-commit run --all-files' with SKIP= needs.
+      #
+      # The fixture pairs a passing hook with one that always FAILS,
+      # so the assertion cannot succeed by accident: without a working
+      # '--skip' this step fails.
+      # yamllint disable-line rule:line-length
+      - name: "Running local action: ${{ github.repository }} [Skip hooks/run-all]"
+        id: skipped
+        uses: ./
+        with:
+          no_checkout: true
+          config_path: 'resources/skip-hooks-fixture.yaml'
+          skip_hooks: 'always-fails'
+
+      - name: 'Check the run-all-except case succeeded'
+        shell: bash
+        env:
+          HOOKS_RUN: ${{ steps.skipped.outputs.hooks_run }}
+        run: |
+          # Check the run-all-except case succeeded
+          if [ "$HOOKS_RUN" != 'all' ]; then
+            echo 'Error: expected the run-all path ❌'
+            echo "Got: $HOOKS_RUN"
+            exit 1
+          fi
+          echo 'run-all with a failing hook excluded passed ✅'
+
+      # The per-hook path invokes prek differently: one call per id.
+      # An excluded id must be removed from the LIST rather than left
+      # in it and passed to '--skip'. Measured against prek 0.4.14,
+      # 'prek run --skip b -- b' exits 1 with 'No hooks found after
+      # filtering', so leaving it in recorded a CROSS and failed the
+      # run for a hook the caller asked to exclude -- while hooks_run
+      # still claimed it had run.
+      # yamllint disable-line rule:line-length
+      - name: "Running local action: ${{ github.repository }} [Skip hooks/per-hook]"
+        id: skipped_subset
+        uses: ./
+        with:
+          no_checkout: true
+          config_path: 'resources/skip-hooks-fixture.yaml'
+          hooks: 'always-passes, always-fails'
+          skip_hooks: 'always-fails'
+
+      - name: 'Check the excluded hook left the reported set'
+        shell: bash
+        env:
+          HOOKS_RUN: ${{ steps.skipped_subset.outputs.hooks_run }}
+        run: |
+          # Check the excluded hook left the reported set
+          if [ "$HOOKS_RUN" != 'always-passes' ]; then
+            echo 'Error: hooks_run must report what RAN ❌'
+            echo "Got: $HOOKS_RUN"
+            exit 1
+          fi
+          echo 'Excluded hook dropped from the run and the report ✅'
+
+      # Excluding EVERY hook is coherent -- narrowing a shared
+      # configuration down to nothing for one project -- and must be a
+      # no-op in both modes. prek left to itself disagrees: it exits 1
+      # with 'No hooks found after filtering', so the action decides
+      # this before invoking it.
+      # yamllint disable-line rule:line-length
+      - name: "Running local action: ${{ github.repository }} [Skip hooks/all excluded]"
+        id: skipped_all
+        uses: ./
+        with:
+          no_checkout: true
+          config_path: 'resources/skip-hooks-fixture.yaml'
+          skip_hooks: 'always-passes, always-fails'
+
+      - name: 'Check excluding every hook is a no-op'
+        shell: bash
+        env:
+          HOOKS_RUN: ${{ steps.skipped_all.outputs.hooks_run }}
+        run: |
+          # Check excluding every hook is a no-op
+          if [ -n "$HOOKS_RUN" ]; then
+            echo 'Error: expected no hooks to run ❌'
+            echo "Got: $HOOKS_RUN"
+            exit 1
+          fi
+          echo 'Excluding every hook succeeded quietly ✅'
+
       # A configuration named on purpose runs in full, so this covers
       # the run-all path even though the remote file has no ci.skip.
       # yamllint disable-line rule:line-length
@@ -232,6 +319,28 @@ jobs:
           hooks: '*'
         continue-on-error: true
 
+      # skip_hooks reaches the same command line as hooks, and
+      # '--skip' takes its value as a SEPARATE argument -- so there is
+      # no '--' terminator to fall back on and validation is the only
+      # lock. A leading '-' must be refused here too.
+      - name: 'Option-shaped id in skip_hooks'
+        id: option_skip
+        uses: ./
+        with:
+          no_checkout: true
+          run_all_hooks: true
+          skip_hooks: '--help'
+        continue-on-error: true
+
+      - name: 'Glob in skip_hooks'
+        id: glob_skip
+        uses: ./
+        with:
+          no_checkout: true
+          run_all_hooks: true
+          skip_hooks: '*'
+        continue-on-error: true
+
       - name: 'Error if any rejection case did NOT fail'
         shell: bash
         env:
@@ -240,6 +349,8 @@ jobs:
           BAD_DIGEST: ${{ steps.bad_digest.outcome }}
           OPTION_HOOK: ${{ steps.option_hook.outcome }}
           GLOB_HOOK: ${{ steps.glob_hook.outcome }}
+          OPTION_SKIP: ${{ steps.option_skip.outcome }}
+          GLOB_SKIP: ${{ steps.glob_skip.outcome }}
         run: |
           # Error if any rejection case did NOT fail
           status=0
@@ -248,7 +359,9 @@ jobs:
             "plaintext http config_url:$INSECURE_URL" \
             "mismatched config_sha256:$BAD_DIGEST" \
             "hook id that is a prek option:$OPTION_HOOK" \
-            "glob as a hook id:$GLOB_HOOK"; do
+            "glob as a hook id:$GLOB_HOOK" \
+            "option-shaped id in skip_hooks:$OPTION_SKIP" \
+            "glob in skip_hooks:$GLOB_SKIP"; do
             if [ "${check##*:}" = 'success' ]; then
               echo "Error: ${check%:*} was NOT rejected ❌"
               status=1

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Run every hook from a remote configuration, with integrity pinning
 | Variable Name | Required | Description                                                           | Default |
 | ------------- | -------- | --------------------------------------------------------------------- | ------- |
 | hooks         | False    | Space/comma separated hook ids to run; empty runs the ci.skip hooks   |         |
+| skip_hooks    | False    | Space/comma separated hook ids to EXCLUDE from whichever set runs     |         |
 | run_all_hooks | False    | Run every hook in the configuration (exclusive with hooks)            | false   |
 | config_path   | False    | Configuration path; workspace-relative, or absolute in RUNNER_TEMP    |         |
 | config_url    | False    | HTTPS download URL for the configuration (exclusive with config_path) |         |
@@ -97,6 +98,32 @@ Mode selection:
    run every hook in the configuration
 3. Neither (default): run the hooks listed under `ci.skip` in the
    configuration; succeed with a notice when the list is empty
+
+`skip_hooks` is orthogonal to all three: it EXCLUDES ids from
+whichever set the mode above selected, and gives the one way to say
+"run everything except these" — `hooks` names a subset to include,
+which cannot express an exclusion.
+
+It applies by two mechanisms, because the two modes resolve the hook
+set in different places:
+
+<!-- markdownlint-disable MD013 -->
+
+| Mode                          | Who chooses the set | How exclusions apply              |
+| ----------------------------- | ------------------- | --------------------------------- |
+| `run_all_hooks`               | prek                | passed through as `--skip`        |
+| `hooks`, or default `ci.skip` | this action         | subtracted from the resolved list |
+
+<!-- markdownlint-enable MD013 -->
+
+The distinction matters for `hooks_run`, which reports what actually
+ran rather than what the caller asked for. Excluding every hook is a
+clean no-op in both modes.
+
+Note that prek treats a `--skip` id matching no hook as a no-op, so a
+stale entry narrows nothing and the run stays green. Unlike `hooks`,
+nothing can catch a typo here: an id absent from the configuration is
+indistinguishable from an exclusion whose hook has since gone.
 
 A configuration named on purpose runs in full. Its `ci.skip` describes
 what pre-commit.ci skips for the repository that owns it, which says

--- a/action.yaml
+++ b/action.yaml
@@ -16,6 +16,9 @@
 #
 # Other modes:
 #   * hooks: '<ids>'        run an explicit subset of hooks
+#   * skip_hooks: '<ids>'   EXCLUDE ids from whichever set runs
+#     (passed to prek as '--skip' under run_all_hooks; subtracted
+#     from the resolved list in per-hook mode)
 #   * run_all_hooks: 'true' run every hook in the configuration
 #   * config_path/config_url select an alternate configuration file,
 #     which runs in full unless 'hooks' names a subset
@@ -27,6 +30,9 @@
 #     through expression interpolation inside 'run' blocks.
 #   * Hook ids are allow-listed to [A-Za-z0-9._-], so a configuration
 #     cannot smuggle shell metacharacters onto the prek command line.
+#     skip_hooks is held to the same rule: '--skip' takes its value as
+#     a separate argument, so there is no '--' terminator to fall back
+#     on there.
 #   * config_path is confined to the workspace or the runner temp
 #     directory (symlink escapes rejected via realpath).
 #   * config_url must be HTTPS, downloads to a private mktemp
@@ -56,6 +62,28 @@ inputs:
       or config_url implies this.
     required: false
     default: 'false'
+  skip_hooks:
+    description: >-
+      Space or comma separated hook ids to EXCLUDE from the run, the
+      inverse of the hooks input. Held to the same id rules. This is
+      how a caller expresses 'run everything except these', which the
+      hooks input cannot: hooks names a subset to include.
+
+      Combines with run_all_hooks (run everything but these) and with
+      hooks (run these, minus any also named here) alike.
+
+      Applied by two mechanisms, because the two modes resolve the
+      hook set in different places. Under run_all_hooks, prek chooses
+      the set, so the ids pass to it as '--skip'. In per-hook mode
+      this action chooses the set, so the ids are subtracted from it
+      here and never reach prek -- which keeps hooks_run reporting
+      what ran rather than what was asked for. Excluding every hook
+      is a no-op in both.
+
+      Prek treats an id that matches no hook as a no-op, so a stale
+      entry weakens the run without failing it; keep the list current.
+    required: false
+    default: ''
   config_path:
     description: >-
       Path to the pre-commit configuration file. Relative paths
@@ -131,6 +159,7 @@ runs:
       shell: bash
       env:
         INPUT_HOOKS: ${{ inputs.hooks }}
+        INPUT_SKIP_HOOKS: ${{ inputs.skip_hooks }}
         INPUT_RUN_ALL_HOOKS: ${{ inputs.run_all_hooks }}
         INPUT_CONFIG_PATH: ${{ inputs.config_path }}
         INPUT_CONFIG_URL: ${{ inputs.config_url }}
@@ -165,6 +194,7 @@ runs:
         }
 
         check_clean "$INPUT_HOOKS" 'hooks' || true
+        check_clean "$INPUT_SKIP_HOOKS" 'skip_hooks' || true
         check_clean "$INPUT_CONFIG_PATH" 'config_path' || true
         check_clean "$INPUT_CONFIG_URL" 'config_url' || true
         check_clean "$INPUT_PATH_PREFIX" 'path_prefix' || true
@@ -194,6 +224,20 @@ runs:
             if ! printf '%s' "$hook_id" |
               grep -qE '^[A-Za-z0-9][A-Za-z0-9._-]*$'; then
               err "invalid hook id: $hook_id"
+            fi
+          done
+        fi
+        # skip_hooks reaches the same command line, so it is held to
+        # the same rule. A leading '-' here would be read as a prek
+        # option just as readily, and '--skip' takes its value as a
+        # separate argument, so there is no '--' terminator to lean
+        # on for this one.
+        if [ -n "$INPUT_SKIP_HOOKS" ]; then
+          read -ra skip_ids <<< "${INPUT_SKIP_HOOKS//,/ }"
+          for skip_id in "${skip_ids[@]}"; do
+            if ! printf '%s' "$skip_id" |
+              grep -qE '^[A-Za-z0-9][A-Za-z0-9._-]*$'; then
+              err "invalid hook id in skip_hooks: $skip_id"
             fi
           done
         fi
@@ -345,10 +389,14 @@ runs:
       shell: bash
       env:
         INPUT_HOOKS: ${{ inputs.hooks }}
+        INPUT_SKIP_HOOKS: ${{ inputs.skip_hooks }}
         INPUT_RUN_ALL_HOOKS: ${{ inputs.run_all_hooks }}
         INPUT_CONFIG_PATH: ${{ inputs.config_path }}
         INPUT_CONFIG_URL: ${{ inputs.config_url }}
         INPUT_PATH_PREFIX: ${{ inputs.path_prefix }}
+        # Needed by the run-all skip_hooks precheck, which asks
+        # 'prek list' what survives the exclusions.
+        INPUT_PREK_VERSION: ${{ inputs.prek_version }}
         DOWNLOADED_CONFIG: ${{ steps.download.outputs.config_file }}
       run: |
         # Resolve configuration and hooks
@@ -381,6 +429,7 @@ runs:
         hooks=''
         run_all='false'
         run_needed='true'
+        no_work_reason=''
         if [ -n "$INPUT_HOOKS" ]; then
           hooks=$(printf '%s' "$INPUT_HOOKS" | tr ',' ' ' |
             tr -s ' ' | sed -e 's/^ //' -e 's/ $//')
@@ -431,12 +480,100 @@ runs:
           )
           if [ -z "$hooks" ]; then
             run_needed='false'
-            echo '::notice::ci.skip lists no runnable hooks;' \
-              'nothing to do ✅'
+            no_work_reason='ci.skip lists no runnable hooks'
+            echo "::notice::$no_work_reason; nothing to do ✅"
           fi
         fi
 
-        if [ "$run_all" = 'true' ]; then
+        # Subtract the exclusions from the RESOLVED list, before the
+        # label and before the run loop.
+        #
+        # Without this the loop still iterates an excluded id, and
+        # hooks_run still reports it. Measured against prek 0.4.14,
+        # 'prek run --skip b -- b' exits 1 with 'No hooks found after
+        # filtering', so the summary recorded a CROSS and failed the
+        # run for a hook the caller asked to exclude -- while
+        # hooks_run claimed it had run.
+        if [ -n "$INPUT_SKIP_HOOKS" ] && [ "$run_all" != 'true' ] &&
+          [ -n "$hooks" ]; then
+          read -ra skip_ids <<< "${INPUT_SKIP_HOOKS//,/ }"
+          kept=''
+          for hook_id in $hooks; do
+            excluded='false'
+            for skip_id in "${skip_ids[@]}"; do
+              if [ "$hook_id" = "$skip_id" ]; then
+                excluded='true'
+                break
+              fi
+            done
+            if [ "$excluded" = 'false' ]; then
+              kept="${kept:+$kept }$hook_id"
+            fi
+          done
+          hooks="$kept"
+          if [ -z "$hooks" ]; then
+            run_needed='false'
+            no_work_reason='skip_hooks excluded every selected hook'
+            echo "::notice::$no_work_reason; nothing to do ✅"
+          fi
+        fi
+
+        # The same question for run-all mode, where prek resolves the
+        # set rather than this action -- so the emptiness has to be
+        # anticipated instead of observed.
+        #
+        # Excluding every hook is coherent (a caller narrowing a
+        # shared configuration down to nothing for one project), and
+        # the per-hook path above already treats it as a clean no-op.
+        # Left to prek it is not: measured against 0.4.14,
+        #
+        #   $ prek run --all-files --config cfg.yaml \
+        #       --skip always-passes --skip always-fails
+        #   error: No hooks found after filtering with the given
+        #   selectors
+        #   exit=1
+        #
+        # One input would then mean 'nothing to do' in one mode and
+        # 'fail the job' in the other.
+        #
+        # Ask PREK what survives rather than inferring it from the
+        # YAML. An earlier version walked 'repos[].hooks[].id' here,
+        # which is not prek's selection: it ignores a hook 'alias',
+        # which '--skip' matches, so excluding a hook by alias left
+        # this precheck seeing it as remaining and prek seeing
+        # nothing. 'prek list' applies the same selectors 'prek run'
+        # does, and empty output corresponds exactly to the error
+        # above.
+        if [ -n "$INPUT_SKIP_HOOKS" ] && [ "$run_all" = 'true' ]; then
+          read -ra skip_ids <<< "${INPUT_SKIP_HOOKS//,/ }"
+          list_args=()
+          for skip_id in "${skip_ids[@]}"; do
+            list_args+=(--skip "$skip_id")
+          done
+          list_status=0
+          remaining=$(uvx "prek@$INPUT_PREK_VERSION" list \
+            --config "$cfg" \
+            "${list_args[@]+"${list_args[@]}"}") || list_status=$?
+          if [ "$list_status" -eq 0 ] && [ -z "$remaining" ]; then
+            run_needed='false'
+            no_work_reason='skip_hooks excluded every hook in the'
+            no_work_reason="$no_work_reason configuration"
+            echo "::notice::$no_work_reason; nothing to do ✅"
+          fi
+          # A non-zero status is 'could not tell', not 'nothing to
+          # do'. Fall through and let the run report it, rather than
+          # converting a failed query into a green no-op.
+        fi
+
+        if [ "$run_needed" != 'true' ]; then
+          # Nothing ran, so report nothing. The documented contract
+          # for hooks_run is 'empty when there was nothing to do',
+          # and 'all' here would name work that did not happen --
+          # which is what the run-all label would otherwise say once
+          # skip_hooks excluded every hook. The ci.skip no-op path
+          # reaches the same state through an empty $hooks.
+          hooks_label=''
+        elif [ "$run_all" = 'true' ]; then
           hooks_label='all'
         else
           hooks_label="$hooks"
@@ -448,6 +585,7 @@ runs:
           echo "hooks_label=$hooks_label"
           echo "run_all=$run_all"
           echo "run_needed=$run_needed"
+          echo "no_work_reason=$no_work_reason"
           echo "config_hash=$config_hash"
         } >> "$GITHUB_OUTPUT"
 
@@ -467,6 +605,7 @@ runs:
       env:
         CONFIG_FILE: ${{ steps.resolve.outputs.config_file }}
         RESOLVED_HOOKS: ${{ steps.resolve.outputs.hooks }}
+        INPUT_SKIP_HOOKS: ${{ inputs.skip_hooks }}
         RUN_ALL: ${{ steps.resolve.outputs.run_all }}
         INPUT_PATH_PREFIX: ${{ inputs.path_prefix }}
         INPUT_BRANCH_NAME: ${{ inputs.branch_name }}
@@ -489,9 +628,42 @@ runs:
         fi
         status=0
         rows=''
+        # '--skip' applies to the run-all path ALONE. In per-hook mode
+        # the resolver has already removed the exclusions from the
+        # list, so the loop never names one.
+        #
+        # Passing it there as well would look like defence in depth
+        # and behave as the opposite. Measured against prek 0.4.14:
+        #
+        #   $ prek run --skip always-fails -- always-fails
+        #   warning: selector `always-fails` did not match any hooks
+        #   error: No hooks found after filtering with the given
+        #   selectors
+        #   exit=1
+        #
+        # So should the filter ever fail, the excluded hook records a
+        # cross and fails the run -- a caller punished for an
+        # exclusion they asked for. Without '--skip' the same bug
+        # over-runs the hook instead, which is visible and safe.
+        #
+        # Built as an ARRAY: a single string would either word-split
+        # unquoted -- taking pathname expansion with it -- or arrive
+        # as one argument when quoted, and prek takes one id per
+        # '--skip'. 'read -ra' splits on IFS without globbing, and
+        # validation has already refused anything outside
+        # [A-Za-z0-9._-] or with a leading '-'.
+        skip_args=()
+        if [ -n "$INPUT_SKIP_HOOKS" ]; then
+          read -ra skip_list <<< "${INPUT_SKIP_HOOKS//,/ }"
+          for skip_id in "${skip_list[@]}"; do
+            skip_args+=(--skip "$skip_id")
+          done
+          echo "Skipping hooks: ${skip_list[*]} 💬"
+        fi
         if [ "$RUN_ALL" = 'true' ]; then
           if uvx "prek@$INPUT_PREK_VERSION" run --all-files \
-            --show-diff-on-failure --config "$CONFIG_FILE"; then
+            --show-diff-on-failure --config "$CONFIG_FILE" \
+            "${skip_args[@]+"${skip_args[@]}"}"; then
             rows='| all hooks | ✅ |'
           else
             rows='| all hooks | ❌ |'
@@ -530,10 +702,19 @@ runs:
     - name: 'Nothing to run'
       if: steps.resolve.outputs.run_needed != 'true'
       shell: bash
+      env:
+        NO_WORK_REASON: ${{ steps.resolve.outputs.no_work_reason }}
       run: |
         # Nothing to run
+        #
+        # The reason travels from the resolver rather than being
+        # assumed here. Three paths reach this step now -- an empty
+        # ci.skip, an explicit subset emptied by skip_hooks, and a
+        # configuration whose every hook skip_hooks excluded -- and a
+        # summary naming ci.skip for the other two sends a caller to
+        # look at a key they never used.
         {
           echo '## ⛔️ Standalone Linting'
           echo ''
-          echo 'No hooks to run: ci.skip lists no runnable hooks ✅'
+          echo "No hooks to run: $NO_WORK_REASON ✅"
         } >> "$GITHUB_STEP_SUMMARY"

--- a/resources/skip-hooks-fixture.yaml
+++ b/resources/skip-hooks-fixture.yaml
@@ -1,0 +1,35 @@
+---
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+# Fixture configuration for the skip_hooks tests in testing.yaml.
+#
+# It pairs a hook that always passes with one that always FAILS, so an
+# exclusion test cannot pass by accident. Skipping 'always-fails' has
+# to change the outcome: without a working '--skip' the run fails, and
+# with one it succeeds.
+#
+# An earlier version of that test excluded two hooks which passed
+# anyway, so removing '--skip' altogether produced the same green
+# result -- a fixture asserting nothing about the feature it named.
+#
+# Not discovered by prek's workspace mode: that looks for prek.toml,
+# .pre-commit-config.yaml and .pre-commit-config.yml, and this is none
+# of them. The tests reach it through config_path.
+
+repos:
+  - repo: local
+    hooks:
+      - id: always-passes
+        name: 'Always passes'
+        entry: 'true'
+        language: system
+        pass_filenames: false
+        always_run: true
+
+      - id: always-fails
+        name: 'Always fails'
+        entry: 'false'
+        language: system
+        pass_filenames: false
+        always_run: true


### PR DESCRIPTION
## Summary

Adds `skip_hooks`, an input that EXCLUDES hook ids from whichever set the action would otherwise run.

The action can already say *which hooks run* — it cannot say *which do not*. `hooks` names a subset to **include**, so "run everything except these" has no expression at all. That is the shape a caller migrating from `pre-commit run --all-files` with `SKIP=` needs, and the one Gerrit projects have used historically through `compose-repo-linting.yaml`'s `pre_commit_skips` input.

Raised by a reviewer on lfreleng-actions/generic-workflows#34, which needs this to offer unmodified migration for those consumers.

## Behaviour

`skip_hooks` is orthogonal to the existing mode selection rather than a fourth mode:

| Combination | Runs |
| --- | --- |
| `run_all_hooks: true` + `skip_hooks` | every hook except those named |
| `hooks` + `skip_hooks` | that subset, minus those named |
| default (`ci.skip`) + `skip_hooks` | the `ci.skip` set, minus those named |

Each id maps to one prek `--skip`.

## Security

Held to the same id contract as `hooks` (`[A-Za-z0-9._-]`, must start alphanumeric, no control characters) — and for a sharper reason than symmetry.

`--skip` takes its value as a **separate argument**, so there is no `--` terminator to fall back on the way there is for a hook id. Validation is the only lock, and a leading `-` would reach prek as an option.

The arguments are built as a bash **array**:

```bash
skip_args=()
if [ -n "$INPUT_SKIP_HOOKS" ]; then
  read -ra skip_list <<< "${INPUT_SKIP_HOOKS//,/ }"
  for skip_id in "${skip_list[@]}"; do
    skip_args+=(--skip "$skip_id")
  done
fi
```

A single string would either word-split unquoted — taking pathname expansion with it — or arrive as one argument when quoted. `read -ra` splits on IFS without globbing.

## A documented sharp edge

prek treats a `--skip` id matching no hook as a **no-op**. A stale entry therefore narrows nothing and the run stays green.

Unlike `hooks`, nothing can catch that: an id absent from the configuration is indistinguishable from an exclusion whose hook has since been removed. The README says so rather than leaving it to be discovered.

## Tests

`testing.yaml` gains three cases:

- `run_all_hooks: true` with `skip_hooks` set — asserts the run-all path still selected and succeeded
- `skip_hooks: '--help'` — rejected (the case with no `--` terminator behind it)
- `skip_hooks: '*'` — rejected, proving the glob reaches validation literally rather than expanded against the checkout

Verified against prek 0.4.14 that `--skip` does what the input claims — a config with a passing `keep` hook and a failing `drop` hook:

```console
$ uvx prek@0.4.14 run --all-files --config .pre-commit-config.yaml --skip drop
keep.....................................................................Passed
exit=0
```

## Validation

- `actionlint` — clean
- `zizmor --persona=auditor` with a token — no findings
- `prek run --all-files` — all hooks pass

## Follow-up

`generic-workflows#34` re-pins to the release cut from this change and exposes `skip_hooks` as a passthrough, completing unmodified migration from `compose-repo-linting.yaml`.
